### PR TITLE
Implement org name remapping and user merge mode.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ attachments/
 data.ndjson
 fb.log
 repos.json
+orgs.json
+users.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.4.1",
       "license": "MIT",
       "dependencies": {
+        "@types/async": "^3.2.18",
         "agentkeepalive": "^4.1.3",
         "any-promise": "^1.3.0",
         "async": "^3.2.0",
@@ -949,6 +950,11 @@
       "engines": {
         "node": ">= 10"
       }
+    },
+    "node_modules/@types/async": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@types/async/-/async-3.2.18.tgz",
+      "integrity": "sha512-/IsuXp3B9R//uRLi40VlIYoMp7OzhkunPe2fDu7jGfQXI9y3CDCx6FC4juRLSqrpmLst3vgsiK536AAGJFl4Ww=="
     },
     "node_modules/@types/body-parser": {
       "version": "1.19.2",
@@ -6267,6 +6273,11 @@
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
       "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
       "optional": true
+    },
+    "@types/async": {
+      "version": "3.2.18",
+      "resolved": "https://registry.npmjs.org/@types/async/-/async-3.2.18.tgz",
+      "integrity": "sha512-/IsuXp3B9R//uRLi40VlIYoMp7OzhkunPe2fDu7jGfQXI9y3CDCx6FC4juRLSqrpmLst3vgsiK536AAGJFl4Ww=="
     },
     "@types/body-parser": {
       "version": "1.19.2",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "homepage": "https://github.com/reviewable/enterprise-tools#readme",
   "dependencies": {
+    "@types/async": "^3.2.18",
     "agentkeepalive": "^4.1.3",
     "any-promise": "^1.3.0",
     "async": "^3.2.0",


### PR DESCRIPTION
This adds two major features:

1. You can rename organizations (or owners, more generally) as part of the transform.  Any orgs with no mapping will keep their old name but generate a warning.

2. You can request that the extracted data be structured to enable merging into an instance where some of the users might already have existing records.  Note that only users will be merged; organizations, repositories, and reviews are assumed to be distinct and will fully overwrite.

Besides those, fixed a number of small bugs that I noticed in passing.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/enterprise-tools/9)
<!-- Reviewable:end -->
