### PR TITLE
Allow logging output to be consumed by jq

### DIFF
--- a/read.js
+++ b/read.js
@@ -38,7 +38,8 @@ async function read() {
   await import('./lib/loadFirebase.js');
   args.path = args.path.replace(/^\//, '');
   const value = await db.child(args.path).get();
-  console.log(inspect(value, {depth: null}));
+  // console.log(inspect(value, {depth: null}));
+  console.log(JSON.stringify(value, null, 2));
 }
 
 read().then(() => {


### PR DESCRIPTION
The current implementation emits JSON-like output that fails to use double-quotes, causing `jq` to vomit uncontrollably.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/enterprise-tools/14)
<!-- Reviewable:end -->
