### PR TITLE
Add target option to data extractor

### DIFF
--- a/extract_data.js
+++ b/extract_data.js
@@ -15,7 +15,7 @@ import {uploadedFilesUrl, PLACEHOLDER_URL} from './lib/derivedInfo.js';
 
 const NodeFire = nodefireModule.default;
 
-const TARGETS = ['saas', 'ghes'];
+const HOSTING_ENVIRONMENTS = ['saas', 'ghes'];
 
 const commandLineOptions = [
   {name: 'repos', alias: 'r', typeLabel: '{underline repos.json}',
@@ -29,9 +29,23 @@ const commandLineOptions = [
   {name: 'merge', alias: 'm', type: Boolean,
     description: 'Extract data in a format suitable for merging users into an existing instance'},
   {
+    name: 'source',
+    type: value => {
+      if (!_.includes(HOSTING_ENVIRONMENTS, value)) {
+        throw new Error(`Expected one of: ${HOSTING_ENVIRONMENTS.join(', ')}`);
+      }
+      return value;
+    },
+    defaultValue: 'saas',
+    typeLabel: '{underline saas|ghes}',
+    description: 'Source hosting environment. (Optional, defaults to saas.)'
+  },
+  {
     name: 'target',
     type: value => {
-      if (!_.includes(TARGETS, value)) throw new Error(`Expected one of: ${TARGETS.join(', ')}`);
+      if (!_.includes(HOSTING_ENVIRONMENTS, value)) {
+        throw new Error(`Expected one of: ${HOSTING_ENVIRONMENTS.join(', ')}`);
+      }
       return value;
     },
     defaultValue: 'ghes',
@@ -89,7 +103,8 @@ const repoNames =
   _(args.repos).thru(fs.readFileSync).thru(JSON.parse).map(_.toLower).uniq().value();
 const repoNamesSet = new Set(repoNames);
 const orgNames = _(repoNames).map(name => name.replace(/\/.*/, '')).uniq().value();
-const ghostUserKey = args.target === 'saas' ? 'github:10137' : 'github:1';
+const sourceGhostUserKey = args.source === 'saas' ? 'github:10137' : 'github:1';
+const targetGhostUserKey = args.target === 'saas' ? 'github:10137' : 'github:1';
 
 const out = new PromiseWritable(fs.createWriteStream(args.output));
 out.stream.setMaxListeners(Infinity);
@@ -385,7 +400,7 @@ async function extractUsers() {
   if (_.isEmpty(userMap)) return;
   log('Extracting users');
   await forEachOfLimit(userMap, 25, async (newUserKey, oldUserKey) => {
-    if (newUserKey === ghostUserKey) return;
+    if (newUserKey === targetGhostUserKey) return;
     let user = await db.child('users/:oldUserKey', {oldUserKey}).get();
     if (!user) {
       unknownUsers.push(oldUserKey);
@@ -473,8 +488,8 @@ function mapUserKey(userKey, context) {
     userMap[userKey] = userKey;
     pace.total += 1;
   }
-  const newUserKey = userMap[userKey] || ghostUserKey;
-  if (!userMap[userKey] && userKey !== ghostUserKey) ghostedUsers.push({userKey, context});
+  const newUserKey = userMap[userKey] || targetGhostUserKey;
+  if (!userMap[userKey] && userKey !== sourceGhostUserKey) ghostedUsers.push({userKey, context});
   return newUserKey;
 }
 

--- a/extract_data.js
+++ b/extract_data.js
@@ -15,6 +15,8 @@ import {uploadedFilesUrl, PLACEHOLDER_URL} from './lib/derivedInfo.js';
 
 const NodeFire = nodefireModule.default;
 
+const TARGETS = ['saas', 'ghes'];
+
 const commandLineOptions = [
   {name: 'repos', alias: 'r', typeLabel: '{underline repos.json}',
     description: 'A file with a JSON array of "owner/repo" repo names to extract.'},
@@ -26,6 +28,16 @@ const commandLineOptions = [
       'user id mappings. (Optional, defaults to identity mapping.)'},
   {name: 'merge', alias: 'm', type: Boolean,
     description: 'Extract data in a format suitable for merging users into an existing instance'},
+  {
+    name: 'target',
+    type: value => {
+      if (!_.includes(TARGETS, value)) throw new Error(`Expected one of: ${TARGETS.join(', ')}`);
+      return value;
+    },
+    defaultValue: 'ghes',
+    typeLabel: '{underline saas|ghes}',
+    description: 'Target hosting environment. (Optional, defaults to ghes.)'
+  },
   {name: 'output', alias: 'o', typeLabel: '{underline data.ndjson}',
     description: 'Output ndJSON file for extracted data.'},
   {name: 'download', alias: 'd', typeLabel: '{underline file/download/dir}',
@@ -77,6 +89,7 @@ const repoNames =
   _(args.repos).thru(fs.readFileSync).thru(JSON.parse).map(_.toLower).uniq().value();
 const repoNamesSet = new Set(repoNames);
 const orgNames = _(repoNames).map(name => name.replace(/\/.*/, '')).uniq().value();
+const ghostUserKey = args.target === 'saas' ? 'github:10137' : 'github:1';
 
 const out = new PromiseWritable(fs.createWriteStream(args.output));
 out.stream.setMaxListeners(Infinity);
@@ -372,7 +385,7 @@ async function extractUsers() {
   if (_.isEmpty(userMap)) return;
   log('Extracting users');
   await forEachOfLimit(userMap, 25, async (newUserKey, oldUserKey) => {
-    if (newUserKey === 'github:1') return;
+    if (newUserKey === ghostUserKey) return;
     let user = await db.child('users/:oldUserKey', {oldUserKey}).get();
     if (!user) {
       unknownUsers.push(oldUserKey);
@@ -460,8 +473,8 @@ function mapUserKey(userKey, context) {
     userMap[userKey] = userKey;
     pace.total += 1;
   }
-  const newUserKey = userMap[userKey] || 'github:1';
-  if (!userMap[userKey] && userKey !== 'github:1') ghostedUsers.push({userKey, context});
+  const newUserKey = userMap[userKey] || ghostUserKey;
+  if (!userMap[userKey] && userKey !== ghostUserKey) ghostedUsers.push({userKey, context});
   return newUserKey;
 }
 

--- a/extract_data.js
+++ b/extract_data.js
@@ -484,7 +484,9 @@ function mapAllUserKeys(object, context) {
 }
 
 function mapUserKey(userKey, context) {
-  if (identityUserMap && !userMap[userKey]) {
+  if (identityUserMap && userKey === sourceGhostUserKey) return targetGhostUserKey;
+  // A real source user may collide with the target ghost ID; leave it unmapped so it is reported.
+  if (identityUserMap && !userMap[userKey] && userKey !== targetGhostUserKey) {
     userMap[userKey] = userKey;
     pace.total += 1;
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "reviewable-enterprise-tools",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "reviewable-enterprise-tools",
-      "version": "3.1.0",
+      "version": "3.2.0",
       "license": "MIT",
       "dependencies": {
         "@types/async": "^3.2.18",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "reviewable-enterprise-tools",
-  "version": "3.1.0",
+  "version": "3.2.0",
   "type": "module",
   "description": "Admin tools for Reviewable Enterprise",
   "bin": {


### PR DESCRIPTION
## Summary

- add a validated `--target` option with `saas` and `ghes` values, defaulting to `ghes`
- use the target-specific ghost account (`github:10137` for SaaS and `github:1` for GHES) when mapping and extracting users
- bump `reviewable-enterprise-tools` to version 3.2.0

## Why

The extractor hardcoded the GHES ghost account ID, so exports intended for SaaS could map missing users to the wrong account.

## Validation

- `npm run lint`
- `node ./extract_data.js --target saas --help`
- `node ./extract_data.js --target ghes --help`
- invalid `--target` value rejection
- `git diff --check`

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/Reviewable/enterprise-tools/28)
<!-- Reviewable:end -->
